### PR TITLE
Fixed Accurate Item Restoration Deletion issue

### DIFF
--- a/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChestListener.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChestListener.java
@@ -368,93 +368,22 @@ public class DeadChestListener implements Listener {
                                     // This will store items whose slots have been replaced with new items since death, so that no items are lost.
                                     List<ItemStack> slotReplacedItems = new ArrayList<>();
 
-                                    // First pass: Auto-equip armor and shield from their original equipped slots
-                                    // Minecraft PlayerInventory slots: 0-35 = main inventory, 36=boots, 37=leggings, 38=chestplate, 39=helmet, 40=offhand
-                                    // Don't bother checking main inventory in first pass.
-                                    for (int i = 36; i <= 40; i++) {
-                                        ItemStack item = originalContents[i];
-                                        if (item != null) {
-                                            // Auto-equip helmet from helmet slot (39)
-                                            if (Utils.isHelmet(item) && i == 39) {
-                                                // If helmet slot is empty, restore helmet
-                                                if (playerInventory.getHelmet() == null
-                                                        || playerInventory.getHelmet().getType() == Material.AIR) {
-                                                    playerInventory.setHelmet(item);
-                                                }
-                                                else { // if it wasn't empty, add to inventory later
-                                                    slotReplacedItems.add(item);
-                                                }
-                                                originalContents[i] = null;
-                                            }
-                                            // Auto-equip chestplate from chestplate slot (38)
-                                            else if (Utils.isChestplate(item) && i == 38) {
-                                                // If chestplate slot is empty, restore chestplate
-                                                if (playerInventory.getChestplate() == null
-                                                        || playerInventory.getChestplate().getType() == Material.AIR) {
-                                                    playerInventory.setChestplate(item);
-                                                }
-                                                else { // if it wasn't empty, add to inventory later
-                                                    slotReplacedItems.add(item);
-                                                }
-                                                originalContents[i] = null;
-                                            }
-                                            // Auto-equip leggings from leggings slot (37)
-                                            else if (Utils.isLeggings(item) && i == 37) {
-                                                // If leggings slot is empty, restore leggings
-                                                if (playerInventory.getLeggings() == null
-                                                        || playerInventory.getLeggings().getType() == Material.AIR) {
-                                                    playerInventory.setLeggings(item);
-                                                }
-                                                else { // if it wasn't empty, add to inventory later
-                                                    slotReplacedItems.add(item);
-                                                }
-                                                originalContents[i] = null;
-                                            }
-                                            // Auto-equip boots from boots slot (36)
-                                            else if (Utils.isBoots(item) && i == 36) {
-                                                // If boots slot is empty, restore boots
-                                                if (playerInventory.getBoots() == null
-                                                        || playerInventory.getBoots().getType() == Material.AIR) {
-                                                    playerInventory.setBoots(item);
-                                                }
-                                                else { // if it wasn't empty, add to inventory later
-                                                    slotReplacedItems.add(item);
-                                                }
-                                                originalContents[i] = null;
-                                            }
-                                            // Auto-equip shield to offhand ONLY if it was originally in offhand (slot 40)
-                                            else if (i == 40) {
-                                                // If offhand slot is empty, restore offhand
-                                                if (playerInventory.getItemInOffHand() == null
-                                                        || playerInventory.getItemInOffHand().getType() == Material.AIR) {
-                                                    playerInventory.setItemInOffHand(item);
-                                                }
-                                                else { // if it wasn't empty, add to inventory later
-                                                    slotReplacedItems.add(item);
-                                                }
-                                                originalContents[i] = null;
-                                            }
-                                        }
-                                    }
-
-                                    // Second pass: Restore items to their original inventory positions
-                                    // Only main inventory slots (0-35)
-                                    for (int i = 0; i < originalContents.length && i < 36; i++) {
+                                    // First pass: Restore items to their original inventory positions
+                                    for (int i = 0; i < originalContents.length; i++) {
                                         ItemStack item = originalContents[i];
                                         if (item != null) {
                                             if (i < playerInventory.getSize() && (playerInventory.getItem(i) == null
-                                                || playerInventory.getItem(i).getType() == Material.AIR)) {
+                                                || playerInventory.getItem(i).getType() == Material.AIR))
                                                 playerInventory.setItem(i, item);
-                                            } else {
+                                            else
                                                 // If slot doesn't exist or is occupied, add to slotReplacedItems to be
                                                 // added to first empty slot or dropped
                                                 slotReplacedItems.add(item);
-                                            }
                                         }
                                     }
 
-                                    // Third pass: Restore items that would have replaced existing items
-                                    // Into empty slots or drop them if there are no available slots.
+                                    // Second pass: Restore items that would have replaced existing items
+                                    // into empty slots or drop them if there are no available slots.
                                     for (ItemStack i : slotReplacedItems) {
                                         if (playerInventory.firstEmpty() != -1)
                                             playerInventory.addItem(i);

--- a/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChestListener.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChestListener.java
@@ -469,6 +469,9 @@ public class DeadChestListener implements Listener {
                                             }
                                         }
                                     }
+
+                                    // Third pass: Restore items that would have replaced existing items
+                                    // Into empty slots or drop them if there are no available slots.
                                     for (ItemStack i : slotReplacedItems) {
                                         if (playerInventory.firstEmpty() != -1)
                                             playerInventory.addItem(i);

--- a/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChestListener.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChestListener.java
@@ -262,7 +262,8 @@ public class DeadChestListener implements Listener {
                     ItemStack[] itemsToStore = new ItemStack[playerInv.length];
                     for (int i = 0; i < playerInv.length; i++) {
                         ItemStack item = playerInv[i];
-                        if (item != null && !config.getArray(ConfigKey.IGNORED_ITEMS).contains(item.getType().toString())) {
+                        if (item != null && !config.getArray(ConfigKey.IGNORED_ITEMS).contains(item.getType().toString())
+                            && !isMinePackBackpack(item)) { // MinePacks compatibility: Ignore backpacks
                             itemsToStore[i] = item;
                         }
                         // Keep null for filtered/empty slots to preserve positions
@@ -529,6 +530,21 @@ public class DeadChestListener implements Listener {
                     }
                 }
         }
+    }
+
+    // Used for MinePacks compatibility
+    private boolean isMinePackBackpack(ItemStack item) {
+        if (Bukkit.getServer().getPluginManager().getPlugin("MinePacks") == null)
+            return false; // MinePack not installed
+
+        // All the following logic in this method is taken from MinePack to determine if an item is a backpack.
+        String mpItemName = ChatColor.translateAlternateColorCodes('&',
+            Bukkit.getServer().getPluginManager().getPlugin("MinePacks").getConfig().getString("ItemShortcut.ItemName"));
+        String mpItemNameNoReset = mpItemName.replace(ChatColor.RESET.toString(), "");
+
+        if (item == null || item.getType() != Material.PLAYER_HEAD || !item.hasItemMeta()) return false;
+        String itemDisplayName = item.getItemMeta().getDisplayName();
+        return itemDisplayName != null && mpItemNameNoReset.equals(itemDisplayName.replace(ChatColor.RESET.toString(), ""));
     }
 }
 

--- a/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChestListener.java
+++ b/deadchest-core/src/main/java/me/crylonz/deadchest/DeadChestListener.java
@@ -290,25 +290,6 @@ public class DeadChestListener implements Listener {
                             .filter(item -> !config.getArray(ConfigKey.IGNORED_ITEMS).contains(item.getType().toString()))
                             .collect(Collectors.toList());
 
-                    // Handle MinePacks backpack duplication
-                    if (Bukkit.getServer().getPluginManager().getPlugin("MinePacks") != null) {
-                        // Look for MinePacks backpacks in drops and remove them to prevent duplication
-                        List<ItemStack> minePacksBackpacks = new ArrayList<>();
-                        for (ItemStack drop : e.getDrops()) {
-                            if (drop != null && drop.hasItemMeta() && drop.getItemMeta().hasDisplayName()) {
-                                String displayName = drop.getItemMeta().getDisplayName();
-                                if (displayName.toLowerCase().contains("backpack") ||
-                                        (drop.getItemMeta().hasLore() &&
-                                                drop.getItemMeta().getLore().toString().toLowerCase()
-                                                        .contains("backpack"))) {
-                                    minePacksBackpacks.add(drop);
-                                }
-                            }
-                        }
-                        // Remove MinePacks backpacks from drops to prevent duplication
-                        e.getDrops().removeAll(minePacksBackpacks);
-                    }
-
                     e.getDrops().removeIf(dropDestroy::contains);
 
                     for (ItemStack item : p.getInventory().getContents()) {
@@ -389,7 +370,8 @@ public class DeadChestListener implements Listener {
 
                                     // First pass: Auto-equip armor and shield from their original equipped slots
                                     // Minecraft PlayerInventory slots: 0-35 = main inventory, 36=boots, 37=leggings, 38=chestplate, 39=helmet, 40=offhand
-                                    for (int i = 0; i < originalContents.length; i++) {
+                                    // Don't bother checking main inventory in first pass.
+                                    for (int i = 36; i <= 40; i++) {
                                         ItemStack item = originalContents[i];
                                         if (item != null) {
                                             // Auto-equip helmet from helmet slot (39)
@@ -460,7 +442,8 @@ public class DeadChestListener implements Listener {
                                     for (int i = 0; i < originalContents.length && i < 36; i++) {
                                         ItemStack item = originalContents[i];
                                         if (item != null) {
-                                            if (i < playerInventory.getSize() && playerInventory.getItem(i) == null) {
+                                            if (i < playerInventory.getSize() && (playerInventory.getItem(i) == null
+                                                || playerInventory.getItem(i).getType() == Material.AIR)) {
                                                 playerInventory.setItem(i, item);
                                             } else {
                                                 // If slot doesn't exist or is occupied, add to slotReplacedItems to be

--- a/deadchest-core/src/main/resources/plugin.yml
+++ b/deadchest-core/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: DeadChest
 main: me.crylonz.deadchest.DeadChest
-softdepend: [Multiverse-Core, WorldGuard]
+softdepend: [Multiverse-Core, WorldGuard, MinePacks]
 author: Crylonz
 version: 4.21.2
 description: Keep your inventory in a chest when you die

--- a/deadchest-core/src/main/resources/plugin.yml
+++ b/deadchest-core/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: DeadChest
 main: me.crylonz.deadchest.DeadChest
-softdepend: [Multiverse-Core, WorldGuard, MinePacks]
+softdepend: [Multiverse-Core, WorldGuard]
 author: Crylonz
 version: 4.21.2
 description: Keep your inventory in a chest when you die
@@ -16,13 +16,13 @@ permissions:
     description: Player can open all deadChest
     default: op
   deadchest.infinityChest:
-    description: Player dead chest never disappaear
+    description: Player dead chest never disappear
     default: false
   deadchest.giveBack:
     description: Allow a player to give back a deadchest to a player
     default: op
   deadchest.admin:
-    description: Player dead chest never disappaear
+    description: Player dead chest never disappear
     default: op
   deadchest.remove.own:
     description: Allow a player to remove his deadchest


### PR DESCRIPTION
Fixed an issue where accurate item restoration would overwrite items that the player has acquired since dying.

Accomplished by creating a list before restoration begins and saving would-be-replacing items into that list to be added to empty slots or dropped after restoration is complete.